### PR TITLE
Fix ValueError by updating snipls.transform() to use matrix multiplication

### DIFF
--- a/src/direpack/sprm/snipls.py
+++ b/src/direpack/sprm/snipls.py
@@ -318,4 +318,4 @@ class snipls(_BaseComposition, BaseEstimator, TransformerMixin, RegressorMixin):
                 )
             )
         Xnc = scale_data(Xn, self.x_loc_, self.x_sca_)
-        return Xnc * self.x_Rweights_
+        return np.dot(Xnc, self.x_Rweights_)


### PR DESCRIPTION
Changed the last operation in snipls.transform from element-wise multiplication to matrix multiplication with np.dot() to fix ValueError: -operands could not be broadcast together- and transform the input to the reduced space with a shape of (n_smaples x snipls_dimensions)

The error can be reproduced with:
import numpy as np
from direpack import snipls
np.random.seed(123)
X_dummy = np.random.rand(20, 10)
y_dummy = np.random.rand(20)
snipls = snipls(n_components=4, eta=0.5)
snipls.fit(X_dummy, y_dummy)
X_transformed_dummy = snipls.transform(X_dummy)

The output of .transform is expected to be of reduced size in the feature domain, hence matrix multiplication is required. 